### PR TITLE
feat(search): Adding Elastic Search for wiki.js

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,35 @@ services:
       - TZ=${TZ}
     ports:
       - "${WIKI_PORT}:3000"
+    networks:
+      - wikijs
     volumes:
       - ./data/wiki/config:/config
       - ./data/wiki/uploads:/data/uploads
+  
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.5.2
+    container_name: es01
+    environment:
+      - node.name=es01
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - elastic:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - wikijs
+ 
+ 
+networks:
+  wikijs:
+    driver: bridge
+ 
+volumes:
+  elastic:


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` file to add support for running an Elasticsearch service alongside the existing Wiki.js service. It also introduces a custom Docker network and a named volume for persistent Elasticsearch data.

**Service integration and networking:**

* Added a new `elasticsearch` service with appropriate configuration, environment variables, and persistent storage using a named volume (`elastic`).
* Configured both the `wiki` and `elasticsearch` services to use a custom Docker network (`wikijs`) for better service isolation and communication.

**Persistent storage:**

* Defined a new named volume (`elastic`) to persist Elasticsearch data across container restarts.